### PR TITLE
Make tensorflow install optional

### DIFF
--- a/linux_setup.sh
+++ b/linux_setup.sh
@@ -3,7 +3,7 @@
 # Tested on Ubuntu 18.04 LTS, runtime ~5 minutes including a reboot.
 # Miniconda and Tensorflow 1.12 are installed here, but a working Tensorflow 1 environment can substitute.
 # Before running this script, first run `git clone -b v3 https://github.com/aaronkollasch/seqdesign-pytorch.git`
-# and then `cd SeqDesign`
+# and then `cd seqdesign-pytorch`
 # If NVIDIA drivers have not been installed before, this script must be run twice, rebooting the system in between.
 
 if [ ! -f "/proc/driver/nvidia/version" ]; then
@@ -17,22 +17,30 @@ Please reboot your system, then run linux_setup.sh a second time."
 fi
 
 # set up conda and the SeqDesign environment
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-sh Miniconda3-latest-Linux-x86_64.sh -b -p "$HOME"/miniconda3
-rm Miniconda3-latest-Linux-x86_64.sh
+if [ ! -d "$HOME/miniconda3" ]; then
+  echo "miniconda3 not found; installing."
+  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  sh Miniconda3-latest-Linux-x86_64.sh -b -p "$HOME"/miniconda3
+  rm Miniconda3-latest-Linux-x86_64.sh
+fi
 "$HOME"/miniconda3/bin/conda init
-"$HOME"/miniconda3/bin/conda create -n seqdesign -y -c pytorch python=3.7 pytorch "tensorflow-gpu>=1.12,<2" scipy "scikit-learn<0.22" gitpython pandas biopython pillow
+"$HOME"/miniconda3/bin/conda install mamba -n base -c conda-forge
+"$HOME"/miniconda3/bin/mamba create -n seqdesign -y -c pytorch python=3.7 pip pytorch scipy scikit-learn gitpython pandas biopython pillow
 "$HOME"/miniconda3/envs/seqdesign/bin/python -c "import torch; print(torch.cuda.is_available()); print([torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())])"  # test GPU install
+"$HOME"/miniconda3/bin/conda install -y -n seqdesign "tensorflow>1.12,<2"  # necessary to read tensorflow model files
 #"$HOME"/miniconda3/envs/seqdesign/bin/python -c "from tensorflow.python.client import device_lib; print(device_lib.list_local_devices())"  # test GPU install
 
 # download SeqDesign code:
 # git clone -b v3 https://github.com/aaronkollasch/seqdesign-pytorch.git
 # cd seqdesign-pytorch || exit
-"$HOME"/miniconda3/envs/seqdesign/bin/python setup.py install  # use setup.py develop if you want to modify the code files
+"$HOME"/miniconda3/envs/seqdesign/bin/pip install .  # use setup.py develop if you want to modify the code files
 
 # download demo/example data
-cd examples || exit
-./download_example_data.sh
+if [ ! -f examples/datasets/sequences/BLAT_ECOLX_1_b0.5_lc_weights.fa ]; then
+  "echo examples not found; downloading."
+  cd examples || exit
+  ./download_example_data.sh
+fi
 
 echo "
 SeqDesign installed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 torch
-tensorflow>=1.12,<2
 scipy
 numpy
-scikit-learn<0.22
+scikit-learn
 gitpython
 pandas
 biopython

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -1,8 +1,7 @@
 torch
-tensorflow-gpu>=1.12,<2
 scipy
 numpy
-scikit-learn<0.22
+scikit-learn
 gitpython
 pandas
 biopython

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,10 +27,9 @@ classifiers =
 setup_requires =
 install_requires =
     torch
-    tensorflow>=1.12,<2
     scipy
     numpy
-    scikit-learn<0.22
+    scikit-learn
     gitpython
     pandas
     biopython

--- a/src/seqdesign_pt/scripts/calc_logprobs_seqs_fr.py
+++ b/src/seqdesign_pt/scripts/calc_logprobs_seqs_fr.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-import tensorflow as tf
+try:
+    import tensorflow as tf
+    from seqdesign_pt.tf_reader import TFReader
+except ImportError:
+    TFReader = None
+    class tf:
+        __version__ = None
 import numpy as np
 import pandas as pd
 import argparse
@@ -12,7 +18,6 @@ from seqdesign_pt import autoregressive_train
 from seqdesign_pt import utils
 from seqdesign_pt import aws_utils
 from seqdesign_pt import data_loaders
-from seqdesign_pt.tf_reader import TFReader
 from seqdesign_pt.version import VERSION
 
 
@@ -111,6 +116,9 @@ def main():
 
     print("Initializing and loading variables")
     if args.from_tf:
+        if not TFReader:
+            print("Trying to read tensorflow model but tensorflow could not be imported.")
+            exit(1)
         reader = TFReader(sess_namedir)
         legacy_version = reader.get_checkpoint_legacy_version()
         last_dilation_size = 200 if legacy_version == 0 else 256

--- a/src/seqdesign_pt/scripts/generate_sample_seqs_fr.py
+++ b/src/seqdesign_pt/scripts/generate_sample_seqs_fr.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-import tensorflow as tf
+try:
+    import tensorflow as tf
+    from seqdesign_pt.tf_reader import TFReader
+except ImportError:
+    TFReader = None
+    class tf:
+        __version__ = None
 import numpy as np
 import time
 import sys
@@ -12,7 +18,6 @@ from seqdesign_pt import autoregressive_model
 from seqdesign_pt import utils
 from seqdesign_pt import aws_utils
 from seqdesign_pt import data_loaders
-from seqdesign_pt.tf_reader import TFReader
 from seqdesign_pt.version import VERSION
 
 
@@ -123,6 +128,9 @@ def main():
 
     print("Initializing and loading variables")
     if args.from_tf:
+        if not TFReader:
+            print("Trying to read tensorflow model but tensorflow could not be imported.")
+            exit(1)
         reader = TFReader(sess_namedir)
         legacy_version = reader.get_checkpoint_legacy_version()
         last_dilation_size = 200 if legacy_version == 0 else 256


### PR DESCRIPTION
TensorFlow is only required to load models produced by the TensorFlow version of SeqDesign. Therefore, this pull request removes the requirement for TensorFlow.

TensorFlow will still be installed by linux_setup.sh as the examples use TensorFlow model files.

Fixes #4