### PR TITLE
Make tensorflow optional during training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch
+torch>=1.2
 scipy
 numpy
 scikit-learn

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -1,4 +1,4 @@
-torch
+torch>=1.2
 scipy
 numpy
 scikit-learn

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 [options]
 setup_requires =
 install_requires =
-    torch
+    torch>=1.2
     scipy
     numpy
     scikit-learn

--- a/src/seqdesign_pt/scripts/run_autoregressive_fr.py
+++ b/src/seqdesign_pt/scripts/run_autoregressive_fr.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 import sys
 import json
 import glob
-import tensorflow as tf
 import numpy as np
 import torch
 from seqdesign_pt.version import VERSION
@@ -116,7 +115,6 @@ def main(working_dir='.'):
     else:
         r_seed = args.r_seed
 
-    tf.set_random_seed(r_seed)
     np.random.seed(args.r_seed)
     torch.manual_seed(args.r_seed)
     torch.cuda.manual_seed_all(args.r_seed)
@@ -133,7 +131,6 @@ def main(working_dir='.'):
 
     print("OS: ", sys.platform)
     print("Python: ", sys.version)
-    print("TensorFlow: ", tf.__version__)
     print("Numpy: ", np.__version__)
 
     use_cuda = not args.no_cuda


### PR DESCRIPTION
The tensorflow dependency has been maintained in `run_autoregressive_fr` as tensorboard was used for the summary writer. However, a tensorboard summary writer API has been stabilized in pytorch 1.2.0. This PR switches from tensorflow 1's tensorboard summary writer to pytorch's built-in writer, allowing the tensorflow import to be removed from `run_autoregressive_fr` and `seqdesign_pt.model_logging`.